### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/maximiliandio/9aca1300-5a52-4ff5-a6f5-9016b1b457ba/02314878-2bff-4833-8be1-60d622dde53d/_apis/work/boardbadge/317b6686-8b22-4018-8110-fec03d8aecc4)](https://dev.azure.com/maximiliandio/9aca1300-5a52-4ff5-a6f5-9016b1b457ba/_boards/board/t/02314878-2bff-4833-8be1-60d622dde53d/Microsoft.RequirementCategory)
 # Formulas and Vehicles
 Dieses Repository bildet ein Basis-Setup für die problemorientierte Lehrveranstaltung **Formulas and Vehicles**.
 Unter dem Link zur Dokumentation findet man alle Informationen.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/maximiliandio/9aca1300-5a52-4ff5-a6f5-9016b1b457ba/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.